### PR TITLE
[SYS-1893] Add handler for Xero tokens file

### DIFF
--- a/Ecommerce.jpr
+++ b/Ecommerce.jpr
@@ -527,6 +527,18 @@
             <value n="id" v="Invoices.jar"/>
             <value n="isJDK" v="false"/>
          </hash>
+         <hash>
+            <value n="id" v="Junit-jupiter-api-5.13.2.jar"/>
+            <value n="isJDK" v="false"/>
+         </hash>
+         <hash>
+            <value n="id" v="JUnit 4 Runtime"/>
+            <value n="isJDK" v="false"/>
+         </hash>
+         <hash>
+            <value n="id" v="Gson-2.13.1.jar"/>
+            <value n="isJDK" v="false"/>
+         </hash>
       </list>
       <hash n="internalDefinitions">
          <list n="libraryDefinitions">
@@ -546,6 +558,24 @@
                <value n="deployedByDefault" v="true"/>
                <value n="description" v="Invoices.jar"/>
                <value n="id" v="Invoices.jar"/>
+               <value n="locked" v="true"/>
+            </hash>
+            <hash>
+               <list n="classPath">
+                  <url path="../../jars/lpo/junit-jupiter-api-5.13.2.jar" jar-entry=""/>
+               </list>
+               <value n="deployedByDefault" v="true"/>
+               <value n="description" v="Junit-jupiter-api-5.13.2.jar"/>
+               <value n="id" v="Junit-jupiter-api-5.13.2.jar"/>
+               <value n="locked" v="true"/>
+            </hash>
+            <hash>
+               <list n="classPath">
+                  <url path="../../jars/gson-2.13.1.jar" jar-entry=""/>
+               </list>
+               <value n="deployedByDefault" v="true"/>
+               <value n="description" v="Gson-2.13.1.jar"/>
+               <value n="id" v="Gson-2.13.1.jar"/>
                <value n="locked" v="true"/>
             </hash>
          </list>
@@ -601,6 +631,18 @@
          </hash>
          <hash>
             <value n="id" v="Invoices.jar"/>
+            <value n="isJDK" v="false"/>
+         </hash>
+         <hash>
+            <value n="id" v="Junit-jupiter-api-5.13.2.jar"/>
+            <value n="isJDK" v="false"/>
+         </hash>
+         <hash>
+            <value n="id" v="JUnit 4 Runtime"/>
+            <value n="isJDK" v="false"/>
+         </hash>
+         <hash>
+            <value n="id" v="Gson-2.13.1.jar"/>
             <value n="isJDK" v="false"/>
          </hash>
       </list>

--- a/public_html/resources/default_secrets.txt
+++ b/public_html/resources/default_secrets.txt
@@ -1,0 +1,4 @@
+access_token = eyJhbGciOiJSUzI1Ni
+expires_in = 2025-07-08T16:17:53.186
+refresh_token = wSzpv1rx0k9gCkvGrzXT
+scope = accounting.settings accounting.transactions accounting.contacts offline_access

--- a/src/edu/ucla/library/libservices/webservices/ecommerce/beans/XeroTokenBean.java
+++ b/src/edu/ucla/library/libservices/webservices/ecommerce/beans/XeroTokenBean.java
@@ -1,0 +1,54 @@
+package edu.ucla.library.libservices.webservices.ecommerce.beans;
+
+public class XeroTokenBean
+{
+  private String access_token;
+  private String expires_in;
+  private String refresh_token;
+  private String scope;
+
+  public XeroTokenBean()
+  {
+    super();
+  }
+
+  public void setAccess_token(String access_token)
+  {
+    this.access_token = access_token;
+  }
+
+  public String getAccess_token()
+  {
+    return access_token;
+  }
+
+  public void setExpires_in(String expires_in)
+  {
+    this.expires_in = expires_in;
+  }
+
+  public String getExpires_in()
+  {
+    return expires_in;
+  }
+
+  public void setRefresh_token(String refresh_token)
+  {
+    this.refresh_token = refresh_token;
+  }
+
+  public String getRefresh_token()
+  {
+    return refresh_token;
+  }
+
+  public void setScope(String scope)
+  {
+    this.scope = scope;
+  }
+
+  public String getScope()
+  {
+    return scope;
+  }
+}

--- a/src/edu/ucla/library/libservices/webservices/ecommerce/tests/TokenFileHandlerTest.java
+++ b/src/edu/ucla/library/libservices/webservices/ecommerce/tests/TokenFileHandlerTest.java
@@ -1,0 +1,116 @@
+package edu.ucla.library.libservices.webservices.ecommerce.tests;
+
+import edu.ucla.library.libservices.webservices.ecommerce.beans.XeroTokenBean;
+import edu.ucla.library.libservices.webservices.ecommerce.utility.handlers.TokenFileHandler;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class TokenFileHandlerTest
+{
+  private static String JSON = "{\"access_token\":\"eyJhbGciOiJSUzI1Ni\",\"expires_in\":1800,\"token_type\":\"Bearer\",\"refresh_token\":\"wSzpv1rx0k9gCkvGrzXT\",\"scope\":\"accounting.settings accounting.transactions accounting.contacts offline_access\"}";
+  private static String BASE_PATH = System.getProperty("user.dir").concat("\\public_html\\resources");
+  
+  public TokenFileHandlerTest()
+  {
+  }
+
+  public static void main(String[] args)
+  {
+    String[] args2 =
+    {
+      TokenFileHandlerTest.class.getName()
+    };
+    org.junit
+       .runner
+       .JUnitCore
+       .main(args2);
+  }
+
+  @Before
+  public void setUp()
+    throws Exception
+  {
+  }
+
+  @After
+  public void tearDown()
+    throws Exception
+  {
+  }
+
+  @BeforeClass
+  public static void setUpBeforeClass()
+    throws Exception
+  {
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass()
+    throws Exception
+  {
+  }
+
+  /**
+   * @see edu.ucla.library.libservices.webservices.ecommerce.utility.handlers.TokenFileHandler#writeTokensFile(String)
+   */
+  @Test
+  public void testWriteTokensFile()
+  {
+    TokenFileHandler handler;
+    String tokensFile;
+
+    tokensFile = BASE_PATH.concat("\\test_secrets.txt");
+
+    handler = new TokenFileHandler();
+    handler.setTokensFile(tokensFile);
+    handler.writeTokensFile(JSON);
+    assert( Files.exists(Paths.get(tokensFile)) );
+  }
+
+  /**
+   * @see edu.ucla.library.libservices.webservices.ecommerce.utility.handlers.TokenFileHandler#readTokensFile()
+   */
+  @Test
+  public void testReadTokensFile()
+  {
+    XeroTokenBean result;
+    TokenFileHandler handler;
+    String tokensFile;
+
+    tokensFile = BASE_PATH.concat("\\default_secrets.txt");
+
+    handler = new TokenFileHandler();
+    handler.setTokensFile(tokensFile);
+    result = handler.readTokensFile();
+    assert(result.getAccess_token().equals("eyJhbGciOiJSUzI1Ni"));
+    assert(result.getExpires_in().equals("2025-07-08T16:17:53.186"));
+    assert(result.getRefresh_token().equals("wSzpv1rx0k9gCkvGrzXT"));
+    assert(result.getScope().equals("accounting.settings accounting.transactions accounting.contacts offline_access"));
+  }
+
+  /**
+   * @see edu.ucla.library.libservices.webservices.ecommerce.utility.handlers.TokenFileHandler#setTokensFile(String)
+   */
+  @Test
+  public void testSetTokensFile()
+  {
+    fail("Unimplemented");
+  }
+
+  /**
+   * @see edu.ucla.library.libservices.webservices.ecommerce.utility.handlers.TokenFileHandler#getTokensFile()
+   */
+  @Test
+  public void testGetTokensFile()
+  {
+    fail("Unimplemented");
+  }
+}

--- a/src/edu/ucla/library/libservices/webservices/ecommerce/tests/TokenFileHandlerTest.java
+++ b/src/edu/ucla/library/libservices/webservices/ecommerce/tests/TokenFileHandlerTest.java
@@ -3,6 +3,8 @@ package edu.ucla.library.libservices.webservices.ecommerce.tests;
 import edu.ucla.library.libservices.webservices.ecommerce.beans.XeroTokenBean;
 import edu.ucla.library.libservices.webservices.ecommerce.utility.handlers.TokenFileHandler;
 
+import java.io.IOException;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import static org.junit.Assert.*;
@@ -15,9 +17,10 @@ import java.nio.file.Paths;
 
 public class TokenFileHandlerTest
 {
-  private static String JSON = "{\"access_token\":\"eyJhbGciOiJSUzI1Ni\",\"expires_in\":1800,\"token_type\":\"Bearer\",\"refresh_token\":\"wSzpv1rx0k9gCkvGrzXT\",\"scope\":\"accounting.settings accounting.transactions accounting.contacts offline_access\"}";
+  private static String JSON =
+    "{\"access_token\":\"eyJhbGciOiJSUzI1Ni\",\"expires_in\":1800,\"token_type\":\"Bearer\",\"refresh_token\":\"wSzpv1rx0k9gCkvGrzXT\",\"scope\":\"accounting.settings accounting.transactions accounting.contacts offline_access\"}";
   private static String BASE_PATH = System.getProperty("user.dir").concat("\\public_html\\resources");
-  
+
   public TokenFileHandlerTest()
   {
   }
@@ -63,6 +66,7 @@ public class TokenFileHandlerTest
    */
   @Test
   public void testWriteTokensFile()
+    throws IOException
   {
     TokenFileHandler handler;
     String tokensFile;
@@ -72,7 +76,7 @@ public class TokenFileHandlerTest
     handler = new TokenFileHandler();
     handler.setTokensFile(tokensFile);
     handler.writeTokensFile(JSON);
-    assert( Files.exists(Paths.get(tokensFile)) );
+    assert (Files.exists(Paths.get(tokensFile)));
   }
 
   /**
@@ -90,27 +94,26 @@ public class TokenFileHandlerTest
     handler = new TokenFileHandler();
     handler.setTokensFile(tokensFile);
     result = handler.readTokensFile();
-    assert(result.getAccess_token().equals("eyJhbGciOiJSUzI1Ni"));
-    assert(result.getExpires_in().equals("2025-07-08T16:17:53.186"));
-    assert(result.getRefresh_token().equals("wSzpv1rx0k9gCkvGrzXT"));
-    assert(result.getScope().equals("accounting.settings accounting.transactions accounting.contacts offline_access"));
+    assert (result.getAccess_token().equals("eyJhbGciOiJSUzI1Ni"));
+    assert (result.getExpires_in().equals("2025-07-08T16:17:53.186"));
+    assert (result.getRefresh_token().equals("wSzpv1rx0k9gCkvGrzXT"));
+    assert (result.getScope().equals("accounting.settings accounting.transactions accounting.contacts offline_access"));
   }
 
   /**
    * @see edu.ucla.library.libservices.webservices.ecommerce.utility.handlers.TokenFileHandler#setTokensFile(String)
    */
   @Test
-  public void testSetTokensFile()
+  public void testSetGetTokensFile()
   {
-    fail("Unimplemented");
+    TokenFileHandler handler;
+    String tokensFile;
+
+    tokensFile = BASE_PATH.concat("\\default_secrets.txt");
+
+    handler = new TokenFileHandler();
+    handler.setTokensFile(tokensFile);
+    assert (handler.getTokensFile().equals(tokensFile));
   }
 
-  /**
-   * @see edu.ucla.library.libservices.webservices.ecommerce.utility.handlers.TokenFileHandler#getTokensFile()
-   */
-  @Test
-  public void testGetTokensFile()
-  {
-    fail("Unimplemented");
-  }
 }

--- a/src/edu/ucla/library/libservices/webservices/ecommerce/utility/handlers/TokenFileHandler.java
+++ b/src/edu/ucla/library/libservices/webservices/ecommerce/utility/handlers/TokenFileHandler.java
@@ -1,0 +1,115 @@
+package edu.ucla.library.libservices.webservices.ecommerce.utility.handlers;
+
+import edu.ucla.library.libservices.webservices.ecommerce.beans.XeroTokenBean;
+
+import java.io.BufferedWriter;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.FileReader;
+import java.io.IOException;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.google.gson.Gson;
+
+import java.io.FileNotFoundException;
+
+public class TokenFileHandler
+{
+  private static DateTimeFormatter format = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+  private String tokensFile;
+  
+  public TokenFileHandler()
+  {
+    super();
+  }
+  
+  public void writeTokensFile(String json)
+  {
+    BufferedWriter writer;
+    Gson gson;
+    LocalDateTime expireTime;
+    XeroTokenBean tokens;
+    
+    gson = new Gson();
+    tokens = gson.fromJson(json, XeroTokenBean.class);
+    expireTime = LocalDateTime.now().plusSeconds(Long.parseLong(tokens.getExpires_in()));
+
+    try
+    {
+      writer = new BufferedWriter(new FileWriter(new File(getTokensFile())));
+      writer.write("access_token = " + tokens.getAccess_token());
+      writer.newLine();
+
+      writer.write("expires_in = " + expireTime.format(format));
+      writer.newLine();
+
+      writer.write("refresh_token = " + tokens.getRefresh_token());
+      writer.newLine();
+
+      writer.write("scope = " + tokens.getScope());
+      writer.newLine();
+
+      writer.newLine();
+      writer.flush();
+      writer.close();
+    }
+    catch (IOException ioe)
+    {
+    }
+  }
+  
+  public XeroTokenBean readTokensFile()
+  {
+    BufferedReader reader;
+    String line;
+    XeroTokenBean tokens;
+    
+    tokens = new XeroTokenBean();
+    try
+    {
+      reader = new BufferedReader(new FileReader(new File(getTokensFile())));
+      while ( ( line = reader.readLine() ) != null )
+      {
+        String[] lineTokens;
+        lineTokens = line.split(" = ");
+        switch ( lineTokens[0] ) 
+        {
+          case "access_token" :
+            tokens.setAccess_token(lineTokens[1]);
+            break;
+          case "expires_in" :
+            tokens.setExpires_in(lineTokens[1]);
+            break;
+          case "refresh_token" :
+            tokens.setRefresh_token(lineTokens[1]);
+            break;
+          case "scope" :
+            tokens.setScope(lineTokens[1]);
+            break;
+          default : ; 
+        }
+      }
+      reader.close();
+    }
+    catch (FileNotFoundException fnfe)
+    {
+    }
+    catch (IOException ioe)
+    {
+    }
+    return tokens;
+  }
+  
+  public void setTokensFile(String tokensFile)
+  {
+    this.tokensFile = tokensFile;
+  }
+
+  public String getTokensFile()
+  {
+    return tokensFile;
+  }
+}

--- a/src/edu/ucla/library/libservices/webservices/ecommerce/utility/handlers/TokenFileHandler.java
+++ b/src/edu/ucla/library/libservices/webservices/ecommerce/utility/handlers/TokenFileHandler.java
@@ -14,25 +14,30 @@ import java.time.format.DateTimeFormatter;
 
 import com.google.gson.Gson;
 
+import edu.ucla.library.libservices.webservices.ecommerce.utility.db.DataHandler;
+
 import java.io.FileNotFoundException;
+
+import org.apache.log4j.Logger;
 
 public class TokenFileHandler
 {
-  private static DateTimeFormatter format = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+  private static final Logger LOGGER = Logger.getLogger(DataHandler.class);
+  private static DateTimeFormatter FORMAT = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
   private String tokensFile;
-  
+
   public TokenFileHandler()
   {
     super();
   }
-  
+
   public void writeTokensFile(String json)
   {
     BufferedWriter writer;
     Gson gson;
     LocalDateTime expireTime;
     XeroTokenBean tokens;
-    
+
     gson = new Gson();
     tokens = gson.fromJson(json, XeroTokenBean.class);
     expireTime = LocalDateTime.now().plusSeconds(Long.parseLong(tokens.getExpires_in()));
@@ -43,7 +48,7 @@ public class TokenFileHandler
       writer.write("access_token = " + tokens.getAccess_token());
       writer.newLine();
 
-      writer.write("expires_in = " + expireTime.format(format));
+      writer.write("expires_in = " + expireTime.format(FORMAT));
       writer.newLine();
 
       writer.write("refresh_token = " + tokens.getRefresh_token());
@@ -58,51 +63,55 @@ public class TokenFileHandler
     }
     catch (IOException ioe)
     {
+      LOGGER.error(ioe.getMessage());
     }
   }
-  
+
   public XeroTokenBean readTokensFile()
   {
     BufferedReader reader;
     String line;
     XeroTokenBean tokens;
-    
+
     tokens = new XeroTokenBean();
     try
     {
       reader = new BufferedReader(new FileReader(new File(getTokensFile())));
-      while ( ( line = reader.readLine() ) != null )
+      while ((line = reader.readLine()) != null)
       {
         String[] lineTokens;
         lineTokens = line.split(" = ");
-        switch ( lineTokens[0] ) 
+        switch (lineTokens[0])
         {
-          case "access_token" :
+          case "access_token":
             tokens.setAccess_token(lineTokens[1]);
             break;
-          case "expires_in" :
+          case "expires_in":
             tokens.setExpires_in(lineTokens[1]);
             break;
-          case "refresh_token" :
+          case "refresh_token":
             tokens.setRefresh_token(lineTokens[1]);
             break;
-          case "scope" :
+          case "scope":
             tokens.setScope(lineTokens[1]);
             break;
-          default : ; 
+          default:
+            ;
         }
       }
       reader.close();
     }
     catch (FileNotFoundException fnfe)
     {
+      LOGGER.error(fnfe.getMessage());
     }
     catch (IOException ioe)
     {
+      LOGGER.error(ioe.getMessage());
     }
     return tokens;
   }
-  
+
   public void setTokensFile(String tokensFile)
   {
     this.tokensFile = tokensFile;


### PR DESCRIPTION
* `XeroTokenBean` holds values written to file from Xero token service
* `TokenFileHandler` writes the results of Xero token-service call to file, reads file into `XeroTokenBean` object
* `TokenFileHandlerTest` unit test for `TokenFileHandler` 
* default_secrets.txt file with fake Xero token values for use in unit test